### PR TITLE
Add initial Flutter mobile app structure

### DIFF
--- a/movil-app/lib/main.dart
+++ b/movil-app/lib/main.dart
@@ -1,0 +1,31 @@
+
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Food Delivery',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: HomeScreen(),
+    );
+  }
+}
+
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Home')),
+      body: Center(child: Text('Welcome to the Food Delivery App!')),
+    );
+  }
+}
+

--- a/movil-app/lib/models/order.dart
+++ b/movil-app/lib/models/order.dart
@@ -1,0 +1,14 @@
+
+
+
+
+class Order {
+  final String id;
+  final String restaurantName;
+  final List<String> items;
+
+  Order({required this.id, required this.restaurantName, required this.items});
+}
+
+
+

--- a/movil-app/lib/screens/home_screen.dart
+++ b/movil-app/lib/screens/home_screen.dart
@@ -1,0 +1,16 @@
+
+
+
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Home')),
+      body: Center(child: Text('Welcome to the Food Delivery App!')),
+    );
+  }
+}
+
+

--- a/movil-app/lib/services/api_service.dart
+++ b/movil-app/lib/services/api_service.dart
@@ -1,0 +1,24 @@
+
+
+
+
+
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class ApiService {
+  final String baseUrl = 'https://api.yourfoodapp.com';
+
+  Future<List<dynamic>> fetchRestaurants() async {
+    final response = await http.get(Uri.parse('$baseUrl/restaurants'));
+    if (response.statusCode == 200) {
+      return json.decode(response.body);
+    } else {
+      throw Exception('Failed to load restaurants');
+    }
+  }
+}
+
+
+
+

--- a/movil-app/lib/widgets/custom_button.dart
+++ b/movil-app/lib/widgets/custom_button.dart
@@ -1,0 +1,28 @@
+
+
+
+
+
+import 'package:flutter/material.dart';
+
+class CustomButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const CustomButton({required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      child: Text(label),
+      style: ElevatedButton.styleFrom(
+        padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      ),
+    );
+  }
+}
+
+
+
+

--- a/movil-app/pubspec.yaml
+++ b/movil-app/pubspec.yaml
@@ -1,0 +1,22 @@
+
+name: movil_app
+description: A new Flutter project.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.15.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION


This pull request adds the initial structure for a Flutter mobile application within the `movil-app` directory. The structure includes:

- Basic Flutter project setup with `pubspec.yaml`
- Main application entry point (`lib/main.dart`)
- Home screen implementation (`lib/screens/home_screen.dart`)
- Order model (`lib/models/order.dart`)
- API service for fetching restaurants (`lib/services/api_service.dart`)
- Custom button widget (`lib/widgets/custom_button.dart`)

This sets the foundation for developing the mobile application that will integrate with the existing restaurant backend.

